### PR TITLE
refactor: Refactored schema definitions

### DIFF
--- a/models.js
+++ b/models.js
@@ -1,81 +1,62 @@
-const mongoose= require('mongoose');
+const mongoose = require('mongoose');
 const bcrypt = require('bcrypt');
 
-// schema defines for document in movie collection
-let movieSchema = mongoose.Schema(
-    {
-    Title : {type: String, required: true},
-    Description: { type: String, required:true},
-    Genres: { 
-        name: String,
-        description: String
-     },
-    Directors:{
-        name: String,
-        bio : String,
-        birth_year: Date,
-        death_year: Date
-    },
-    Actors:[{ 
-        name: String,
-        birth_date: Date
-    }],
+// Schema for movies
+let movieSchema = mongoose.Schema({
+    Title: { type: String, required: true },
+    Description: { type: String, required: true },
+    Genres: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Genre' }],  // Reference to Genre schema
+    Directors: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Director' }],  // Reference to Director schema
+    Actors: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Actor' }],  // Reference to Actor schema
     imageURL: String,
     Release_Date: Date,
-    Ratings: Number, 
+    Ratings: Number,
     Featured: Boolean
-}
-
-); 
-let genreSchema = mongoose.Schema(
-    {
-        name: String,
-        description: String
-    }
-);
-
-let directorSchema = mongoose.Schema(
-    {
-        name: String,
-        bio : String,
-        birth_year: Date,
-        death_year: Date
-    }
-);
-
-let actorSchema= mongoose.Schema(
-    {
-        name: String,
-        birth_date: Date
-    }
-);
-
-let userSchema = mongoose.Schema(
-    {
-        username: {type:String, required: true},
-        password: {type: String, required: true},
-        email: {type: String, required: true},
-        birth_date: Date,
-        favorite_movies: [{type: mongoose.Schema.Types.ObjectId, ref: 'Movie'}]
 });
-userSchema.statics.hashPassword = (password)=>{
+
+// Schema for genres
+let genreSchema = mongoose.Schema({
+    name: String,
+    description: String
+});
+
+// Schema for directors
+let directorSchema = mongoose.Schema({
+    name: String,
+    bio: String,
+    birth_year: Date,
+    death_year: Date
+});
+
+// Schema for actors
+let actorSchema = mongoose.Schema({
+    name: String,
+    birth_date: Date
+});
+
+// Schema for users
+let userSchema = mongoose.Schema({
+    username: { type: String, required: true },
+    password: { type: String, required: true },
+    email: { type: String, required: true },
+    birth_date: Date,
+    favorite_movies: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Movie' }]  // Reference to Movie schema
+});
+
+// Password hashing and validation methods for User schema
+userSchema.statics.hashPassword = (password) => {
     return bcrypt.hashSync(password, 12);
 };
-userSchema.methods.validatePassword = function(password){
+userSchema.methods.validatePassword = function (password) {
     return bcrypt.compareSync(password, this.password);
 };
 
-// these will create a collection of db.movies & db.users
-let Movie= mongoose.model('Movie', movieSchema);
-let Genre= mongoose.model('Genre', genreSchema);
+// Model creation
+let Movie = mongoose.model('Movie', movieSchema);
+let Genre = mongoose.model('Genre', genreSchema);
 let Director = mongoose.model('Director', directorSchema);
 let Actor = mongoose.model('Actor', actorSchema);
-let User= mongoose.model('User', userSchema);
+let User = mongoose.model('User', userSchema);
 
-
-// exports these two models to index.js
-module.exports.Movie = Movie;
-module.exports.Genre = Genre;
-module.exports.Director= Director;
-module.exports.Actor= Actor;
-module.exports.User = User;
+// Exporting the models
+module.exports = { Movie, Genre, Director, Actor, User };


### PR DESCRIPTION
Here's a breakdown of the changes made and explanations in this:

1. Changed `Genres`, `Directors`, and `Actors` in `movieSchema` to be arrays of ObjectIds referencing the `Genre`, `Director`, and `Actor` schemas respectively. This is a typical way to define relationships in Mongoose, allowing you to populate these fields with documents from the referenced schemas when querying the database.
2. Changed `favorite_movies` in `userSchema` to be an array of ObjectIds referencing the `Movie` schema, similar to the changes made in `movieSchema`.
3. Modified the export statement at the bottom to use object shorthand, which is a more concise way to export multiple items. This is not related to the relationships between schemas, but is a cleaner way to write your exports.

These changes will enable you to create relationships between your schemas, making your data model more expressive and easier to work with.