### PR TITLE
refactor (index.js) : include director, actor and genre details in re…

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,16 +56,21 @@ app.get('/', (req, res) => {
 
 
 
-// Get all movies
+// Get all movies along with director details
 app.get('/movies', passport.authenticate('jwt', {session:false}), (req,res)=>{
-  Movies.find().then((movies)=>{
-    res.status(201).json(movies);
-  })
-  .catch((err)=>{
-    console.error(err);
-    res.status(500).send('Error : ' + err)
-  })
-})
+  Movies.find()
+    .populate('Directors')  // Populate director details. Assumes 'Directors' is the field name in your Movie schema.
+    .populate('Actors')  // Populate actor details. Assumes 'Actors' is the field name in your Movie schema.
+    .populate('Genres')  // Populate genre details. Assumes 'Genres' is the field name in your Movie schema.
+    .then((movies)=>{
+      res.status(200).json(movies);  // Changed status code to 200 as it's more semantically correct for a successful GET request
+    })
+    .catch((err)=>{
+      console.error(err);
+      res.status(500).send('Error : ' + err);
+    });
+});
+
 
 // Get a movie by title
 app.get('/movies/:Title', passport.authenticate('jwt', {session: false}), (req, res) => {


### PR DESCRIPTION

In this:

1. The `populate()` method is chained to the `find()` method, with the argument `'Directors'` specifying the path to populate. This assumes that `Directors` is the field name in your `Movie` schema where director references are stored.
2. The status code in the `json()` method has been changed to `200`, as this is a more semantically correct status code for a successful GET request. The `201 Created` status code is typically used for successful POST requests where a new resource has been created.
  
By using the `populate()` method in this manner, the `Directors` field in each movie document will be replaced with the actual director documents from the `Director` collection, including all the director details. Make sure the field names match your schema definitions.

Same was repeated for Genres and Actors, this assumes [these changes](https://github.com/GitashreeMahato/myFlix-App/pull/1) have been made